### PR TITLE
WIP: Add edit-submanifest feature (delete documents & cargo, resubmit pending)

### DIFF
--- a/smartportApp/static/shipper/js/edit-shipment.js
+++ b/smartportApp/static/shipper/js/edit-shipment.js
@@ -62,7 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const getDynamicInputToCardMap = () => {
     const baseMap = {
       billOfLadingInput: "bill_of_ladingCard",
-      commercialInvoiceInput: "commercial_invoiceCard",
+      commercialInvoiceInput: "invoiceCard",
       packingListInput: "packing_listCard",
       certificateOriginInput: "certificate_of_originCard",
       othersInput: "othersCard",

--- a/smartportApp/static/shipper/js/edit-shipment.js
+++ b/smartportApp/static/shipper/js/edit-shipment.js
@@ -64,7 +64,7 @@ document.addEventListener("DOMContentLoaded", () => {
       billOfLadingInput: "bill_of_ladingCard",
       commercialInvoiceInput: "commercial_invoiceCard",
       packingListInput: "packing_listCard",
-      certificateOriginInput: "certificate_originCard",
+      certificateOriginInput: "certificate_of_originCard",
       othersInput: "othersCard",
     };
 

--- a/smartportApp/templates/smartportApp/shipper/edit-shipment.html
+++ b/smartportApp/templates/smartportApp/shipper/edit-shipment.html
@@ -623,7 +623,7 @@
   <div class="modal">
     <div class="modal-header">
       <h2 class="modal-title">
-        Are you sure you want to remove this document upload?
+        Delete Existing File?
       </h2>
       <button
         class="modal-close"
@@ -636,8 +636,8 @@
     <div class="modal-body">
       <div class="modal-warning">
         <i class="fas fa-exclamation-triangle icon"></i>
-        Are you sure you want to delete this uploadeded file? This action cannot
-        be undone.
+        This file will be permanently deleted. 
+        To upload a new one, the current file must be removed first.
       </div>
 
       <div


### PR DESCRIPTION
What
Implemented delete functionality for documents.
Implemented delete functionality for cargo.
Initial groundwork for edit-submanifest feature.

Why
Needed to enable editing of submanifests as part of feature requirements.
Delete operations are now functional, but resubmit flow is not yet completed.

How
Added delete endpoints for documents and cargo.
Updated UI to reflect deletions in real time.
Resubmit logic not yet integrated — will be added in a follow-up.